### PR TITLE
Update to newest versions, set actual schema version for ce_dataschema header

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.commercehub.gradle.plugin.avro' version '0.99.99'
+    id 'com.github.davidmc24.gradle.plugin.avro' version '1.5.0'
     id 'java'
     id 'java-library'
     id 'maven'

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,8 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
     testImplementation 'org.apache.kafka:kafka_2.12:2.7.0'
 
-    compileOnly 'org.projectlombok:lombok:1.18.18'
-	annotationProcessor 'org.projectlombok:lombok:1.18.16'
+    compileOnly 'org.projectlombok:lombok:1.18.24'
+	annotationProcessor 'org.projectlombok:lombok:1.18.24'
 }
 
 group = 'io.github.kattlo'

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ dependencies {
     implementation 'org.apache.avro:avro:1.11.1'
     implementation 'io.cloudevents:cloudevents-kafka:2.4.0'
 
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.7.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
     testImplementation 'org.apache.kafka:kafka_2.12:2.7.0'
 
     compileOnly 'org.projectlombok:lombok:1.18.18'

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 dependencies {
     implementation 'io.confluent:kafka-avro-serializer:7.2.1'
     implementation 'org.apache.avro:avro:1.11.1'
-    implementation 'io.cloudevents:cloudevents-kafka:2.0.0'
+    implementation 'io.cloudevents:cloudevents-kafka:2.4.0'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.7.1'

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ dependencies {
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
-    testImplementation 'org.apache.kafka:kafka_2.12:2.7.0'
+    testImplementation 'org.apache.kafka:kafka_2.12:3.2.3'
 
     compileOnly 'org.projectlombok:lombok:1.18.24'
 	annotationProcessor 'org.projectlombok:lombok:1.18.24'

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 dependencies {
     implementation 'io.confluent:kafka-avro-serializer:7.2.1'
-    implementation 'org.apache.avro:avro:1.10.2'
+    implementation 'org.apache.avro:avro:1.11.1'
     implementation 'io.cloudevents:cloudevents-kafka:2.0.0'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.7.1'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.confluent:kafka-avro-serializer:5.5.3'
+    implementation 'io.confluent:kafka-avro-serializer:7.2.1'
     implementation 'org.apache.avro:avro:1.10.2'
     implementation 'io.cloudevents:cloudevents-kafka:2.0.0'
 

--- a/src/main/java/io/github/kattlo/cloudevents/KafkaAvroCloudEventSerializer.java
+++ b/src/main/java/io/github/kattlo/cloudevents/KafkaAvroCloudEventSerializer.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Headers;
 
@@ -70,7 +71,7 @@ public class KafkaAvroCloudEventSerializer extends KafkaAvroSerializer {
                 configs.get(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG);
 
             log.debug("{}={}", KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
-                schemaRegistryUrl);;
+                schemaRegistryUrl);
 
         } else {
             throw new IllegalArgumentException(CloudEventSerializer.ENCODING_CONFIG + "=" + encoding + " not supported");
@@ -109,8 +110,7 @@ public class KafkaAvroCloudEventSerializer extends KafkaAvroSerializer {
 
             // get the versionId of registered schema
             try {
-                var versions = super.schemaRegistry.getAllVersions(subjectName);
-                var version = versions.get(versions.size() -1);
+                var version = super.schemaRegistry.getVersion(subjectName, new AvroSchema(value.getSchema()));
                 log.debug("Schema versionId {}", version);
 
                 var dataschema = schemaRegistryUrl + "/subjects/" + subjectName + "/versions/" + version + "/schema";

--- a/src/main/java/io/github/kattlo/cloudevents/KafkaAvroCloudEventSerializer.java
+++ b/src/main/java/io/github/kattlo/cloudevents/KafkaAvroCloudEventSerializer.java
@@ -147,7 +147,7 @@ public class KafkaAvroCloudEventSerializer extends KafkaAvroSerializer {
         }
 
         @Override
-        public boolean isBackwardCompatible(ParsedSchema arg0) {
+        public List<String> isBackwardCompatible(ParsedSchema arg0) {
             throw new UnsupportedOperationException();
         }
 


### PR DESCRIPTION
The current implementation sets the last schema version. This could differ fro the actual schema version when producing with multiple producers and schema versions.